### PR TITLE
implicitly add handler to function using a partial 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ from py_agent.jobs import github_notifications
 from py_agent.listeners import add_issue_to_todoist, add_pr_to_todoist
 
 agent = Agent()
+task = agent.create_partial(github_notifications)
 
-agent.schedule.every(10).seconds.do(github_notifications, handler=agent.handler)
+agent.schedule.every(10).seconds.do(task)
 
 agent.add_listener(add_issue_to_todoist, {'event_type': ('==', 'new_issue_assigned')})
 agent.add_listener(add_pr_to_todoist, {'event_type': ('==', 'new_pr_review')})

--- a/src/py_agent/agent.py
+++ b/src/py_agent/agent.py
@@ -6,6 +6,8 @@ import logging
 from py_agent.db import init_db
 from py_agent.event_handler import EventHandler
 
+from functools import partial
+
 logging.basicConfig(level=logging.INFO)
 
 
@@ -35,3 +37,5 @@ class Agent:
             except Exception:
                 logging.error("Job failed", exc_info=True)
 
+    def create_partial(self, task):
+        return partial(task, handler=self.handler)


### PR DESCRIPTION
Untested. You may not be able to create partials of partials, which will happen when the task is passed to do().
This eliminates the need to pass agent.handler to schedule and now you don't need to access the handler outside of the class. 